### PR TITLE
Failed redaction on an inner record

### DIFF
--- a/LogRedactionDemo.SimpleWorker/LogRedactionDemo.SimpleWorker.csproj
+++ b/LogRedactionDemo.SimpleWorker/LogRedactionDemo.SimpleWorker.csproj
@@ -11,6 +11,6 @@
         <PackageReference Include="Microsoft.Extensions.Compliance.Redaction" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="8.1.0" />
     </ItemGroup>
 </Project>

--- a/LogRedactionDemo.SimpleWorker/Program.cs
+++ b/LogRedactionDemo.SimpleWorker/Program.cs
@@ -43,7 +43,7 @@ public class Worker : BackgroundService
         {
             if (_logger.IsEnabled(LogLevel.Information))
             {
-                // Redacts the Name and Email properties of the User object, but not the InnerData property's RedactedData property
+                // Redacts the Name and Email properties of the User object, but not the InnerData property's RedactedData property, unless Transitive = true is set
                 _logger.UserLoggedIn(new User("abcd", "Charles", "charles.mingus@bluenote.com", new InnerUserData()));
             }
 

--- a/LogRedactionDemo.SimpleWorker/Program.cs
+++ b/LogRedactionDemo.SimpleWorker/Program.cs
@@ -84,7 +84,9 @@ public record InnerUserData
 public static partial class Log
 {
     [LoggerMessage(LogLevel.Information, "User logged in")]
-    public static partial void UserLoggedIn(this ILogger logger, [LogProperties] User user);
+#pragma warning disable EXTEXP0003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    public static partial void UserLoggedIn(this ILogger logger, [LogProperties(Transitive = true)] User user);
+#pragma warning restore EXTEXP0003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }
 
 public class PersonalDataAttribute : DataClassificationAttribute

--- a/LogRedactionDemo.SimpleWorker/Program.cs
+++ b/LogRedactionDemo.SimpleWorker/Program.cs
@@ -52,9 +52,9 @@ public class Worker : BackgroundService
     }
 }
 
-public class User
+public record User
 {
-    public User(string Id, string Name, string Email, InnerUserData innerData)
+    public User(string Id, [PersonalData] string Name, [PersonalData] string Email, InnerUserData innerData)
     {
         this.Id = Id;
         this.Name = Name;
@@ -83,7 +83,7 @@ public record InnerUserData
 // logging code that logs the user
 public static partial class Log
 {
-    [LoggerMessage(LogLevel.Information, "User {User} logged in")]
+    [LoggerMessage(LogLevel.Information, "User logged in")]
     public static partial void UserLoggedIn(this ILogger logger, [LogProperties] User user);
 }
 


### PR DESCRIPTION
I was experimenting with Redactor and discovered that it does not redact inner objects that also have the redaction attribute added to inner members.

This example is highlighting how the User object is properly redacting the data details as originally written. The added InnerUserData object was added to demonstrate that the redaction only seems to apply to the first object any nested objects do not apply the redaction property attribute.